### PR TITLE
Реализовано динамическое изменение числа итераций от уровня приближения (задача 10)

### DIFF
--- a/src/ru/gr0946x/ui/JuliaFrame.java
+++ b/src/ru/gr0946x/ui/JuliaFrame.java
@@ -12,7 +12,6 @@ public class JuliaFrame extends JFrame {
 
     private static final int WIDTH = 600;
     private static final int HEIGHT = 600;
-    private static final int MAX_ITER = 300;
 
     private double zoom = 1.0;
     private double offsetX = 0;
@@ -73,20 +72,25 @@ public class JuliaFrame extends JFrame {
             super.paintComponent(g);
             BufferedImage image = new BufferedImage(getWidth(), getHeight(), BufferedImage.TYPE_INT_RGB);
 
+            // В переменной zoom хранится масштаб (чем меньше значение, тем ближе).
+            // Считаем динамическое количество итераций (базово 300)
+            int currentMaxIter = (int) (300 + 150 * Math.abs(Math.log10(zoom)));
+            currentMaxIter = Math.max(100, Math.min(currentMaxIter, 2000)); // Защита от зависаний
+
             for (int x = 0; x < getWidth(); x++) {
                 for (int y = 0; y < getHeight(); y++) {
                     double zr = (x - getWidth() / 2.0) * zoom / getWidth() * 3.0 + offsetX;
                     double zi = (y - getHeight() / 2.0) * zoom / getHeight() * 2.0 + offsetY;
 
                     int iter = 0;
-                    while (zr * zr + zi * zi < 4.0 && iter < MAX_ITER) {
+                    while (zr * zr + zi * zi < 4.0 && iter < currentMaxIter) {
                         double temp = zr * zr - zi * zi + realC;
                         zi = 2.0 * zr * zi + imagC;
                         zr = temp;
                         iter++;
                     }
 
-                    int color = getColor(iter, MAX_ITER);
+                    int color = getColor(iter, currentMaxIter);
                     image.setRGB(x, y, color);
                 }
             }

--- a/src/ru/gr0946x/ui/MainWindow.java
+++ b/src/ru/gr0946x/ui/MainWindow.java
@@ -50,6 +50,16 @@ public class MainWindow extends JFrame {
             var yMax = conv.yScr2Crt(r.y);
             conv.setXShape(xMin, xMax);
             conv.setYShape(yMin, yMax);
+
+            // Вычисляем ширину текущего окна (чем она меньше, тем сильнее зум)
+            double currentWidth = xMax - xMin;
+            // Изначальная ширина примерно 3.0. Считаем логарифм отношения для плавного роста итераций.
+            // Базово 100 итераций, добавляем по 100 за каждый порядок приближения.
+            int newIterations = (int) (100 + 100 * Math.abs(Math.log10(currentWidth / 3.0)));
+            // Ограничиваем сверху, чтобы программа не зависла намертво при диком зуме (максимум 2000)
+            newIterations = Math.min(newIterations, 2000);
+
+            ((Mandelbrot)mandelbrot).setMaxIterations(newIterations);
             mainPanel.repaint();
         });
         setContent();

--- a/src/ru/gr0946x/ui/fractals/Mandelbrot.java
+++ b/src/ru/gr0946x/ui/fractals/Mandelbrot.java
@@ -7,11 +7,14 @@ import static java.lang.Math.sqrt;
 
 public class Mandelbrot implements Fractal{
 
-    private final int maxIterations = 100;
-    private final double R2 = 4;
+    private int maxIterations = 100;
+    private double R2 = 4;
     public double getR(){
         return sqrt(R2);
     }
+
+
+    public void setMaxIterations(int maxIterations) => this.maxIterations = maxIterations;
 
     @Override
     public float inSetProbability(double x, double y) {


### PR DESCRIPTION
Для множества Мандельброта:
В классе Mandelbrot убрана привязка к жесткой константе maxIterations, добавлен метод для её изменения. В MainWindow при выделении области (зуме) высчитывается новое число итераций по логарифмической формуле (зависит от размера выделенной области) и передается во фрактал. Чем сильнее зум — тем выше детализация.
Для множества Жюлиа:
В JuliaFrame удалена константа MAX_ITER. Максимальное число итераций теперь вычисляется динамически при каждой перерисовке в методе paintComponent. Оно зависит от текущего уровня масштаба (zoom), которым управляют скроллом мыши.
Защита от зависаний:
Для обоих фракталов установлен верхний предел (до 2000 итераций), чтобы при экстремальном приближении программа не уходила в бесконечные вычисления и не зависала.